### PR TITLE
Fix: Puma binding for fly.io

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -24,6 +24,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT") { 3000 }
+bind "tcp://0.0.0.0:3000"
 
 # Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV") { "development" }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,5 @@ rm -f /app/tmp/pids/server.pid
 
 # bundle exec rails db:prepare
 
-exec "$@"
+# exec "$@"
+exec bundle exec rails s -b 0.0.0.0 -p 3000


### PR DESCRIPTION
#概要
エラー内容

> WARNING The app is not listening on the expected address and will not be reachable by fly-proxy. Machine 1853d07a125978 is now in a good state
> You can fix this by configuring your app to listen on the following addresses:
>   - 0.0.0.0:3000

⇨Fly.ioのプロキシがアプリにアクセスするにはアプリが「0.0.0.0」のIP（全インターフェース）ポート「3000」で起動している必要があるのに、現状はその設定になっていない

原因：Puma が 0.0.0.0 にバインドしていない？
⇨・puma.rbへ0.0.0.0バインドするよう指示
　・念の為、entrypoint.shの起動を-b 0.0.0.0 で明確に指定