### PR TITLE
Fix デプロイエラーのため（デフォルト画像関連）

### DIFF
--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -18,7 +18,7 @@ class PostImageUploader < CarrierWave::Uploader::Base
   # ファイルがアップロードされていない場合にデフォルトで表示する画像のURLを指定
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    "post_placeholder"
+    "post_placeholder.png"
   end
   # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,3 +11,8 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
+
+# プリコンパイルの対象に明示的に画像を加えるため
+# config.assets.precompile に明示的に追加したファイルは必ずプリコンパイルの対象になる
+Rails.application.config.assets.precompile += %w( post_placeholder.png )
+


### PR DESCRIPTION
＃概要

マージ後のデプロイで、POSTに画像が設定されなかったときのデフォルト画像設定するよう記述したものの、本番環境では以下のエラーになった。
> E, [2025-07-06T10:15:20.241404 #149] ERROR -- : [9f1ae40c-9408-4cac-9be0-260fe0b375ce]   
> [9f1ae40c-9408-4cac-9be0-260fe0b375ce] ActionView::Template::Error (The asset "post_placeholder" is not present in the asset pipeline.

修正箇所
デフォルト画像をコンパイル対象にするよう明示的に記述
