### PR TITLE
17 #20 account public

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,18 @@ class ApplicationController < ActionController::Base
 
   # devise利用の機能(ユーザー登録やログイン認証等)を使う前に、configure_permitted_parametersメソッドが実行
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+
+  # 新規登録後の遷移先指定(deviseのデフォはroot_pathのため)
+  def after_sign_up_path_for(resource)
+    posts_path
+  end
+
+  # ログイン後の遷移先指定(deviseのデフォはroot_pathのため)
+  def after_sign_in_path_for(resource)
+    posts_path
+  end
+
   # 未ログインでログイン必須ページへアクセスしたときログインページへリダイレクトされる（deviseのヘルパーメソッド）
   before_action :authenticate_user!
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   def index
     # @posts = Post.includes(:tags, :user).order(created_at: :desc)
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:tags, :user).order(created_at: :desc)
+    @posts = @q.result(distinct: true).includes(:tags, :user).where(users: { is_public: true }).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :introduction)
+    params.require(:user).permit(:name, :introduction, :is_public)
   end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,6 +19,12 @@
           <%= f.text_area :introduction, class: "form-control", rows: 4, placeholder: "自己紹介文を入力（200文字以内）" %>
         </div>
 
+        <!-- 公開/非公開設定 -->
+        <div class="form-group">
+          <%= f.label :is_public, "アカウントを公開する" %>
+          <%= f.check_box :is_public %>
+        </div>
+
         <!-- 保存ボタン -->
         <div class="text-end">
           <%= f.submit "保存", class: "btn btn-outline-dark" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,12 @@
     <div class="col-md-7">
       <div class="d-flex justify-content-between flex-wrap">
         <div>
-          <h2 class="fw-bold d-inline me-2"><%= @user.name %></h2>
+          <h2 class="fw-bold d-inline me-2">
+            <%= @user.name %>
+            <% unless @user.is_public? %>
+              <i class="bi bi-lock-fill text-muted small" title="非公開アカウント"></i>
+            <% end %>
+          </h2>
           <!-- プロフィール編集アイコン -->
           <% if @user == current_user %>
             <%= link_to edit_mypage_path, class: 'text-muted', title: 'プロフィール編集' do %>
@@ -37,13 +42,21 @@
   </div>
 
   <!-- 投稿一覧（フィード） -->
-  <% if @posts.present? %>
-    <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-4 g-4">
-      <%= render partial: "posts/post_mypage", collection: @posts, as: :post %>
+  <% if @user == current_user || @user.is_public? %>
+    <% if @posts.present? %>
+      <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-4 g-4">
+        <%= render partial: "posts/post_mypage", collection: @posts, as: :post %>
+    <% else %>
+      <div class="row">
+        <div class="col-12 text-center">
+          <p>投稿はまだありません。</p>
+        </div>
+      </div>
+    <% end %>
   <% else %>
     <div class="row">
       <div class="col-12 text-center">
-        <p>投稿はまだありません。</p>
+        <p>このユーザーの投稿は非公開です。</p>
       </div>
     </div>
   <% end %>

--- a/db/migrate/20250712085821_add_is_public_to_users.rb
+++ b/db/migrate/20250712085821_add_is_public_to_users.rb
@@ -1,0 +1,21 @@
+class AddIsPublicToUsers < ActiveRecord::Migration[7.2]
+  def up
+    # 1. 一時的に null を許可してカラムを追加（default は任意）
+    add_column :users, :is_public, :boolean, default: true, null: true
+
+    # 2. スキーマ情報を更新して新しいカラムを認識させる
+    User.reset_column_information
+
+    # 3. 既存レコードに明示的に true を代入（null を避ける）
+    User.update_all(is_public: true)
+
+    # 4. null を禁止に（制約を追加）
+    change_column_null :users, :is_public, false
+  end
+
+  def down
+    # ロールバック時にカラムを削除
+    # 安全にロールバックできるよう書いているだけ。migrateが成功すれば実際には処理されないメソッド。
+    remove_column :users, :is_public
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_12_043552) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_12_085821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_07_12_043552) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "introduction"
+    t.boolean "is_public", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
#概要

- usersテーブルへis_publicカラム追加（アカウント公開非公開設定のため）
- User#editビューのフォームへ公開/非公開欄追加
- Post#indexは公開アカウントの投稿のみ表示
- 非公開アカウントの場合は、マイページのアカウント名横に鍵アイコン追加
- 非公開アカウントのマイページへURLから遷移した場合、プロフィールのみ閲覧でき、投稿部分は非表示とした
- 自分のマイページでは公開非公開に関わらず、全ての投稿表示

微修正
- 新規登録後とログイン後の遷移先をPost#indexへ設定し直した（デフォルトでrootとなっていたため）