### PR TITLE
Fix 他人マイページでのタグ検索の場合のurl修正

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -36,7 +36,7 @@
     <!-- 検索フォーム（約40% = col-md-5） -->
     <div class="col-md-5 d-flex justify-content-end align-items-end">
       <div class="w-100 col-sm-12 col-md-6 col-lg-4">
-        <%= render partial: 'posts/search_form', locals: { q: @q, url: mypage_path } %>
+        <%= render partial: 'posts/search_form', locals: { q: @q, url: (@user == current_user ? mypage_path : user_path(@user)) } %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#概要

- 他人マイページでのタグ検索が、ログイン中ユーザーの投稿内での検索結果になっていたため修正