### PR TITLE
デプロイ時の自動migrateを一旦コメントアウト

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -3,4 +3,4 @@ set -o errexit
 bundle install
 bundle exec rails assets:precompile
 # bundle exec rails assets:clean
-bundle exec rails db:migrate
+# bundle exec rails db:migrate #DB移行のため一時的に無効化


### PR DESCRIPTION
#概要

DB移行時、自動migrateがエラー要因となるため一旦コメントアウト